### PR TITLE
replace button-1 with button

### DIFF
--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -5,13 +5,13 @@ import Link from '@/components/Link.astro';
 
 const buttonVariants = cva(
 	// Base styles that always apply
-	'block border-1 text-center font-semibold text-white no-underline hover:brightness-150 md:inline md:rounded',
+	'block border text-center font-semibold text-white no-underline hover:brightness-150 md:inline md:rounded',
 	{
 		variants: {
 			appearance: {
 				primary:
-					'bg-fac-red border-fac-red text-white hover:text-white focus:text-white',
-				secondary: 'hover:border-fac-orange border-white bg-black',
+					'border-fac-red bg-fac-red text-white hover:text-white focus:text-white',
+				secondary: 'border-white bg-black hover:border-fac-orange',
 			},
 			size: {
 				large: 'px-10 py-5 text-2xl',

--- a/src/components/Note.astro
+++ b/src/components/Note.astro
@@ -1,3 +1,3 @@
-<div class='border-border-default mb-4 flex flex-col gap-4 border-b pb-8'>
+<div class='mb-4 flex flex-col gap-4 border-b border-border-default pb-8'>
 	<slot />
 </div>


### PR DESCRIPTION
gemini thinks the issue is my use of `border-1` that is causing the weirdness. tailwindcss has `border` for 1px border. No `border-1` 🫨 

I was also seeing files keep getting auto-updated on save with prettier tailwind shit so I just ran `npx prettier src --write` and scooped up the notes component too.